### PR TITLE
Migrated managed node group to graviton per best practices. cert-mana…

### DIFF
--- a/single-account-single-cluster-multi-env/30.eks/30.cluster/main.tf
+++ b/single-account-single-cluster-multi-env/30.eks/30.cluster/main.tf
@@ -104,7 +104,8 @@ module "eks" {
 
   # managed node group for base EKS addons such as Karpenter 
   eks_managed_node_group_defaults = {
-    instance_types = ["m6i.large", "m5.large"]
+    instance_types = ["t4g.medium", "t4g.large"]
+    ami_type       = "BOTTLEROCKET_ARM_64"
     iam_role_additional_policies = {
       SSM = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
     }
@@ -112,7 +113,7 @@ module "eks" {
   eks_managed_node_groups = {
     "${local.cluster_name}-criticaladdons" = {
       subnet_ids   = data.terraform_remote_state.vpc.outputs.private_subnet_ids
-      max_size     = 5
+      max_size     = 8
       desired_size = 2
       min_size     = 2
 

--- a/single-account-single-cluster-multi-env/30.eks/35.addons/main.tf
+++ b/single-account-single-cluster-multi-env/30.eks/35.addons/main.tf
@@ -27,8 +27,34 @@ module "eks_blueprints_addons" {
   #  ADOT will be deployed as part of the observability accelerator as it's needed specifically for AMP deployment
 
   enable_external_secrets = try(var.observability_configuration.aws_oss_tooling, false)
+  external_secrets = {
+    values = [
+      yamlencode({
+        tolerations = [local.critical_addons_tolerations.tolerations[0]]
+        webhook = {
+          tolerations = [local.critical_addons_tolerations.tolerations[0]]
+        }
+        certController = {
+          tolerations = [local.critical_addons_tolerations.tolerations[0]]
+        }
+      })
+    ]
+  }
 
   enable_cert_manager = try(var.observability_configuration.aws_oss_tooling, false)
+  cert_manager = {
+    values = [
+      yamlencode({
+        tolerations = [local.critical_addons_tolerations.tolerations[0]]
+        webhook = {
+          tolerations = [local.critical_addons_tolerations.tolerations[0]]
+        }
+        cainjector = {
+          tolerations = [local.critical_addons_tolerations.tolerations[0]]
+        }
+      })
+    ]
+  }
 
   enable_aws_for_fluentbit = try(var.observability_configuration.aws_oss_tooling, false)
   aws_for_fluentbit = {


### PR DESCRIPTION
…ger and external-secrets tolerations set to CriticalAddons

*Description of changes:*

Migrated Managed Node Group to Graviton and Set Tolerations for Critical Addons

- Migrated the managed node group to AWS Graviton instances to leverage improved performance and cost efficiency, following AWS best practices.
- Updated cert-manager and external-secrets tolerations to CriticalAddons, ensuring high availability and reliability of these essential components.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
