### PR TITLE
Remove mandatory AWS_PROFILE from the makefile 

### DIFF
--- a/single-account-single-cluster-multi-env/Makefile
+++ b/single-account-single-cluster-multi-env/Makefile
@@ -31,10 +31,7 @@ check-env:
 		echo "AWS_REGION was not set."; \
 		exit 1; \
 	 fi
-	@if [ -z $(AWS_PROFILE) ]; then \
-		echo "AWS_PROFILE was not set."; \
-		exit 1; \
-	 fi
+
 	@if [ ! -f $(VAR_FILE) ]; then \
   		echo "VAR_FILE: $(VAR_FILE) does not exist."; \
   	fi

--- a/single-account-single-cluster-multi-env/Makefile
+++ b/single-account-single-cluster-multi-env/Makefile
@@ -34,6 +34,7 @@ check-env:
 	@if [ ! -f $(VAR_FILE) ]; then \
   		echo "VAR_FILE: $(VAR_FILE) does not exist."; \
   	fi
+
 	@mkdir -p tf-logs
 
 bootstrap: check-env

--- a/single-account-single-cluster-multi-env/Makefile
+++ b/single-account-single-cluster-multi-env/Makefile
@@ -31,7 +31,6 @@ check-env:
 		echo "AWS_REGION was not set."; \
 		exit 1; \
 	 fi
-
 	@if [ ! -f $(VAR_FILE) ]; then \
   		echo "VAR_FILE: $(VAR_FILE) does not exist."; \
   	fi


### PR DESCRIPTION
*Description of changes:*
Some automation processes does not necessarily have `AWS_PROFILE` set, and it's not mandatory as long as there a default AWS credentials or assumed instance profile to run the commands 