### PR TITLE
shorten-node-group-iam-role-name

### DIFF
--- a/single-account-single-cluster-multi-env/30.eks/30.cluster/README.md
+++ b/single-account-single-cluster-multi-env/30.eks/30.cluster/README.md
@@ -97,7 +97,7 @@ terraform apply -var-file="../../00.global/vars/dev.tfvars"
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 20.8.3 |
-| <a name="module_eks_blueprints_addons"></a> [eks\_blueprints\_addons](#module\_eks\_blueprints\_addons) | aws-ia/eks-blueprints-addons/aws | ~> 1.15.1 |
+| <a name="module_eks_blueprints_addons"></a> [eks\_blueprints\_addons](#module\_eks\_blueprints\_addons) | aws-ia/eks-blueprints-addons/aws | ~> 1.16.2 |
 
 ## Resources
 
@@ -105,13 +105,13 @@ terraform apply -var-file="../../00.global/vars/dev.tfvars"
 |------|------|
 | [aws_ec2_tag.cluster_primary_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
 | [aws_eks_access_entry.karpenter_node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_access_entry) | resource |
-| [kubectl_manifest.karpenter_node_class](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
-| [kubectl_manifest.karpenter_node_pool](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.karpenter_manifests](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
 | [null_resource.update-kubeconfig](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ecrpublic_authorization_token.token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecrpublic_authorization_token) | data source |
 | [aws_iam_session_context.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [kubectl_path_documents.karpenter_manifests](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/data-sources/path_documents) | data source |
 | [terraform_remote_state.iam](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.vpc](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 

--- a/single-account-single-cluster-multi-env/30.eks/30.cluster/main.tf
+++ b/single-account-single-cluster-multi-env/30.eks/30.cluster/main.tf
@@ -103,6 +103,7 @@ module "eks" {
   create_node_security_group    = false
 
   # managed node group for base EKS addons such as Karpenter 
+
   eks_managed_node_group_defaults = {
     instance_types = ["t4g.medium", "t4g.large"]
     ami_type       = "BOTTLEROCKET_ARM_64"
@@ -112,10 +113,12 @@ module "eks" {
   }
   eks_managed_node_groups = {
     "${local.cluster_name}-criticaladdons" = {
-      subnet_ids   = data.terraform_remote_state.vpc.outputs.private_subnet_ids
-      max_size     = 8
-      desired_size = 2
-      min_size     = 2
+
+      iam_role_use_name_prefix = false
+      subnet_ids               = data.terraform_remote_state.vpc.outputs.private_subnet_ids
+      max_size                 = 8
+      desired_size             = 2
+      min_size                 = 2
 
       taints = {
         critical_addons = {


### PR DESCRIPTION
setting `iam_role_use_name_prefix` to false to shorten the name of the node IAM role

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
