### PR TITLE
Install EBS CSI Driver EKS add-on

### DIFF
--- a/single-account-single-cluster-multi-env/30.eks/30.cluster/main.tf
+++ b/single-account-single-cluster-multi-env/30.eks/30.cluster/main.tf
@@ -105,8 +105,8 @@ module "eks" {
   # managed node group for base EKS addons such as Karpenter 
 
   eks_managed_node_group_defaults = {
-    instance_types = ["m6i.large", "m5.large"]
-    ami_type       = "AL2_x86_64"
+    instance_types = ["m7g.large", "m6g.large"]
+    ami_type       = "AL2_ARM_64"
     iam_role_additional_policies = {
       SSM = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
     }

--- a/single-account-single-cluster-multi-env/Makefile
+++ b/single-account-single-cluster-multi-env/Makefile
@@ -17,7 +17,7 @@ else
 	TF_AUTO_APPROVE := ""
 endif
 
-.PHONY: print-modules clean check-env bootstrap init-all plan-all apply-all destroy-all init plan apply destroy
+.PHONY: print-modules clean check-env bootstrap init-all plan-all apply-all destroy-all init refresh plan apply destroy
 
 print-modules:
 	@for m in $(MODULES); do echo $$m; done
@@ -92,6 +92,14 @@ tf-select-ws:
 	fi
 	@echo ENVIRONMENT=$(ENVIRONMENT) MODULE=$(MODULE) Switching to Terraform workspace: $(ENVIRONMENT)
 	@terraform -chdir=$(MODULE) workspace select -or-create=true $(ENVIRONMENT)
+
+refresh: init tf-select-ws
+	@echo ENVIRONMENT=$(ENVIRONMENT) MODULE=$(MODULE) terraform::refresh
+	@terraform -chdir=$(MODULE) refresh \
+		-input=false \
+		-lock=true \
+		-var-file=$(VAR_FILE) \
+		2>&1 | tee -a tf-logs/$(notdir $(MODULE))-refresh.log
 
 plan: init tf-select-ws
 	@echo ENVIRONMENT=$(ENVIRONMENT) MODULE=$(MODULE) terraform::plan

--- a/single-account-single-cluster-multi-env/Makefile
+++ b/single-account-single-cluster-multi-env/Makefile
@@ -120,8 +120,8 @@ apply: init tf-select-ws
 
 destroy: init tf-select-ws
 	@echo ENVIRONMENT=$(ENVIRONMENT) MODULE=$(MODULE) terraform::destroy
-	@terraform -chdir=$(MODULE) destroy \
-	$(TF_AUTO_APPROVE) \
+	@terraform -chdir=$(MODULE) apply -destroy \
+	-auto-approve \
 	-input=false \
 	-lock=true \
 	-var-file=$(VAR_FILE) \


### PR DESCRIPTION
* Support for Stateful workloads with EBS CSI Driver
* Use AL2 by default with non burstable instances for MNG
* Add support for terraform refresh in the Makefile

*Issue #, if available:*

*Description of changes:*
* Setup IRSA for the EBS CSI Driver
* Install the EBS CSI Driver EKS add-on
* Add support for terraform refresh in the Makefile
* Use non burstable instances for CriticalAddOns MNG and use AL2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
